### PR TITLE
Fix calculation of potentially overlapping points

### DIFF
--- a/beeswarm/beeswarm.py
+++ b/beeswarm/beeswarm.py
@@ -213,7 +213,7 @@ def swarm(x, xsize=0, ysize=0, colors="black"):
             xi = out["x"].values[i]
             yi = out["y"].values[i]
             pre =  out[0:i] # previous points
-            wh = ((xi-pre["x"]) < 1) # which are potentially overlapping
+            wh = (abs(xi-pre["x"]) < 1) # which are potentially overlapping
             if any(wh):
                 pre = pre[wh]
                 poty_off = pre["x"].apply(lambda x: math.sqrt(1-(xi-x)**2)) # potential y offset


### PR DESCRIPTION
The current implementation can fail with a `ValueError: math domain error` raised in line 219, because (1-(xi-pre["x"])**2) can become negative. This is due to a missing call to abs(), which is there in the [R code](https://github.com/aroneklund/beeswarm/blob/master/R/beeswarm.R#L348). With the call to abs() in place, the ValueError does not occur anymore.
